### PR TITLE
Add spec to email _notification

### DIFF
--- a/spec/models/error_report_spec.rb
+++ b/spec/models/error_report_spec.rb
@@ -51,6 +51,39 @@ describe ErrorReport do
       }.by(1)
     end
 
+    context "when email_at_notices is [0]" do
+      it "sends email" do
+        allow(app).to receive(:emailable?).and_return(true)
+        allow(error_report.app).to receive(:emailable?).and_return(true)
+        allow(error_report.app).to receive(:email_at_notices).and_return([0])
+
+        expect(Mailer).to receive(:err_notification)
+        error_report.generate_notice!
+      end
+    end
+
+    context "when email_at_notices includes problem notice_count" do
+      it "sends email" do
+        allow(app).to receive(:emailable?).and_return(true)
+        allow(error_report.app).to receive(:emailable?).and_return(true)
+        allow(error_report.app).to receive(:email_at_notices).and_return([1])
+
+        expect(Mailer).to receive(:err_notification)
+        error_report.generate_notice!
+      end
+    end
+
+    context "when email_at_notices does not includes problem notice_count" do
+      it "sends email" do
+        allow(app).to receive(:emailable?).and_return(true)
+        allow(error_report.app).to receive(:emailable?).and_return(true)
+        allow(error_report.app).to receive(:email_at_notices).and_return([2])
+
+        expect(Mailer).not_to receive(:err_notification)
+        error_report.generate_notice!
+      end
+    end
+
     context "with a minimal notice" do
       let(:xml) do
         Rails.root.join('spec', 'fixtures', 'minimal_test_notice.xml').read


### PR DESCRIPTION
Hi @ibanez270dx, please review this PR and all my previous commits to errbit. Once review is done, we can ask Hassan to deploy this to staging errbit and add .env.default. 

Some of my changes are already committed against master, some in this PR, they are: 
- Remove .env.default from github repositary
- When ERRBIT_EMAIL_AT_NOTICES = [0], report email each error. Add spec for email_notification.
- set ```config.action_mailer.raise_delivery_errors = true``` for development
- add .ruby-gemset and .ruby-version to git repositary