### PR TITLE
Update env tab to show error from originating request env

### DIFF
--- a/app/controllers/api/v3/notices_controller.rb
+++ b/app/controllers/api/v3/notices_controller.rb
@@ -13,7 +13,7 @@ class Api::V3::NoticesController < ApplicationController
     return render(status: 200, text: '') if request.method == 'OPTIONS'
 
     report = AirbrakeApi::V3::NoticeParser.new(
-      params.merge(JSON.parse(request.raw_post) || {})).report
+      params.merge(request_env: request.env).merge(JSON.parse(request.raw_post) || {})).report
 
     return render text: UNKNOWN_API_KEY, status: 422 unless report.valid?
     return render text: VERSION_TOO_OLD, status: 422 unless report.should_keep?

--- a/app/views/notices/_environment.html.haml
+++ b/app/views/notices/_environment.html.haml
@@ -1,7 +1,7 @@
 .window
   %table.environment
     - html_entities = HTMLEntities.new
-    - request.env.sort_by {|pair| pair[0]}.each do |key, value|
+    - notice.env_vars.sort_by {|pair| pair[0]}.each do |key, value|
       %tr
         %th= h(html_entities.decode(key))
         %td.main= h(html_entities.decode(value))

--- a/lib/airbrake_api/v3/notice_parser.rb
+++ b/lib/airbrake_api/v3/notice_parser.rb
@@ -54,8 +54,32 @@ module AirbrakeApi
       end
 
       def request
+        request_env = params['request_env'] || {}
         environment = (params['environment'] || {}).merge(
-          'HTTP_USER_AGENT' => context['userAgent']
+          'HTTP_ACCEPT' => request_env['HTTP_ACCEPT'],
+          'HTTP_ACCEPT_ENCODING' => request_env['HTTP_ACCEPT_ENCODING'],
+          'HTTP_ACCEPT_LANGUAGE' => request_env['HTTP_ACCEPT_LANGUAGE'],
+          'HTTP_CACHE_CONTROL' => request_env['HTTP_CACHE_CONTROL'],
+          'HTTP_CONNECTION' => request_env['HTTP_CONNECTION'],
+          'HTTP_COOKIE' => request_env['HTTP_COOKIE'],
+          'HTTP_HOST' => request_env['HTTP_HOST'],
+          'HTTP_IF_NONE_MATCH' => request_env['HTTP_IF_NONE_MATCH'],
+          'HTTP_UPGRADE_INSECURE_REQUESTS' => request_env['HTTP_UPGRADE_INSECURE_REQUESTS'],
+          'HTTP_USER_AGENT' => request_env['HTTP_USER_AGENT'],
+          'HTTP_VERSION' => request_env['HTTP_VERSION'],
+          'HTTP_X_AMZ_SERVER_SIDE_ENCRYPTIO' => request_env['HTTP_X_AMZ_SERVER_SIDE_ENCRYPTIO'],
+          'ORIGINAL_FULLPATH' => request_env['ORIGINAL_FULLPATH'],
+          'ORIGINAL_SCRIPT_NAME' => request_env['ORIGINAL_SCRIPT_NAME'],
+          'PATH_INFO' => request_env['PATH_INFO'],
+          'QUERY_STRING' => request_env['QUERY_STRING'],
+          'REMOTE_ADDR' => request_env['REMOTE_ADDR'],
+          'REQUEST_METHOD' => request_env['REQUEST_METHOD'],
+          'REQUEST_PATH' => request_env['REQUEST_PATH'],
+          'REQUEST_URI' => request_env['REQUEST_URI'],
+          'SERVER_NAME' => request_env['SERVER_NAME'],
+          'SERVER_PORT' => request_env['SERVER_PORT'],
+          'SERVER_PROTOCOL' => request_env['SERVER_PROTOCOL'],
+          'SERVER_SOFTWARE' => request_env['SERVER_SOFTWARE']
         )
 
         {

--- a/spec/controllers/api/v3/notices_controller_spec.rb
+++ b/spec/controllers/api/v3/notices_controller_spec.rb
@@ -21,6 +21,8 @@ describe Api::V3::NoticesController, type: :controller do
   it 'returns created notice id in json format' do
     post :create, legit_body, legit_params
     notice = Notice.last
+
+    expect(notice.request["cgi-data"].keys).to eq(["navigator_vendor", "HTTP_ACCEPT", "HTTP_ACCEPT_ENCODING", "HTTP_ACCEPT_LANGUAGE", "HTTP_CACHE_CONTROL", "HTTP_CONNECTION", "HTTP_COOKIE", "HTTP_HOST", "HTTP_IF_NONE_MATCH", "HTTP_UPGRADE_INSECURE_REQUESTS", "HTTP_USER_AGENT", "HTTP_VERSION", "HTTP_X_AMZ_SERVER_SIDE_ENCRYPTIO", "ORIGINAL_FULLPATH", "ORIGINAL_SCRIPT_NAME", "PATH_INFO", "QUERY_STRING", "REMOTE_ADDR", "REQUEST_METHOD", "REQUEST_PATH", "REQUEST_URI", "SERVER_NAME", "SERVER_PORT", "SERVER_PROTOCOL", "SERVER_SOFTWARE"])
     expect(JSON.parse(response.body)).to eq(
       'id'  => notice.id.to_s,
       'url' => notice.problem.url

--- a/spec/lib/airbrake_api/v3/notice_parser_spec.rb
+++ b/spec/lib/airbrake_api/v3/notice_parser_spec.rb
@@ -41,9 +41,33 @@ describe AirbrakeApi::V3::NoticeParser do
     )
     expect(notice.session).to include('isAdmin' => true)
     expect(notice.params).to include('returnTo' => 'dashboard')
+    request_env = {}
     expect(notice.env_vars).to include(
       'navigator_vendor' => 'Google Inc.',
-      'HTTP_USER_AGENT'  => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.99 Safari/537.36'
+      'HTTP_ACCEPT' => request_env['HTTP_ACCEPT'],
+      'HTTP_ACCEPT_ENCODING' => request_env['HTTP_ACCEPT_ENCODING'],
+      'HTTP_ACCEPT_LANGUAGE' => request_env['HTTP_ACCEPT_LANGUAGE'],
+      'HTTP_CACHE_CONTROL' => request_env['HTTP_CACHE_CONTROL'],
+      'HTTP_CONNECTION' => request_env['HTTP_CONNECTION'],
+      'HTTP_COOKIE' => request_env['HTTP_COOKIE'],
+      'HTTP_HOST' => request_env['HTTP_HOST'],
+      'HTTP_IF_NONE_MATCH' => request_env['HTTP_IF_NONE_MATCH'],
+      'HTTP_UPGRADE_INSECURE_REQUESTS' => request_env['HTTP_UPGRADE_INSECURE_REQUESTS'],
+      'HTTP_USER_AGENT' => request_env['HTTP_USER_AGENT'],
+      'HTTP_VERSION' => request_env['HTTP_VERSION'],
+      'HTTP_X_AMZ_SERVER_SIDE_ENCRYPTIO' => request_env['HTTP_X_AMZ_SERVER_SIDE_ENCRYPTIO'],
+      'ORIGINAL_FULLPATH' => request_env['ORIGINAL_FULLPATH'],
+      'ORIGINAL_SCRIPT_NAME' => request_env['ORIGINAL_SCRIPT_NAME'],
+      'PATH_INFO' => request_env['PATH_INFO'],
+      'QUERY_STRING' => request_env['QUERY_STRING'],
+      'REMOTE_ADDR' => request_env['REMOTE_ADDR'],
+      'REQUEST_METHOD' => request_env['REQUEST_METHOD'],
+      'REQUEST_PATH' => request_env['REQUEST_PATH'],
+      'REQUEST_URI' => request_env['REQUEST_URI'],
+      'SERVER_NAME' => request_env['SERVER_NAME'],
+      'SERVER_PORT' => request_env['SERVER_PORT'],
+      'SERVER_PROTOCOL' => request_env['SERVER_PROTOCOL'],
+      'SERVER_SOFTWARE' => request_env['SERVER_SOFTWARE']
     )
   end
 


### PR DESCRIPTION
Fix https://github.com/cognoa/cognoa/issues/1400
The reason for this bug is that when an error is sent to errbit server  errbit handler ```Api::V3::NoticesController#create``` will be called. 
```
Started POST "/api/v3/projects/1/notices?key=9e0f02cea5768843851546fdb78fd4bd" for ::1 at 2017-03-21 11:11:03 -0700
Processing by Api::V3::NoticesController#create as */*
  Parameters: {"errors"=>[{"type"=>"RuntimeError", "message"=>"xxx19", "backtrace"=>[{"file"=>"(pry)", "line"=>26, "function"=>"__pry__"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/pry_instance.rb", "line"=>355, "function"=>"eval"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/pry_instance.rb", "line"=>355, "function"=>"evaluate_ruby"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/pry_instance.rb", "line"=>323, "function"=>"handle_line"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/pry_instance.rb", "line"=>243, "function"=>"block (2 levels) in eval"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/pry_instance.rb", "line"=>242, "function"=>"catch"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/pry_instance.rb", "line"=>242, "function"=>"block in eval"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/pry_instance.rb", "line"=>241, "function"=>"catch"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/pry_instance.rb", "line"=>241, "function"=>"eval"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/repl.rb", "line"=>77, "function"=>"block in repl"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/repl.rb", "line"=>67, "function"=>"loop"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/repl.rb", "line"=>67, "function"=>"repl"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/repl.rb", "line"=>38, "function"=>"block in start"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/input_lock.rb", "line"=>61, "function"=>"__with_ownership"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/input_lock.rb", "line"=>79, "function"=>"with_ownership"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/repl.rb", "line"=>38, "function"=>"start"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/repl.rb", "line"=>15, "function"=>"start"}, {"file"=>"[GEM_ROOT]/gems/pry-0.10.4/lib/pry/pry_class.rb", "line"=>169, "function"=>"start"}, {"file"=>"[GEM_ROOT]/gems/railties-5.0.0.1/lib/rails/commands/console.rb", "line"=>65, "function"=>"start"}, {"file"=>"[GEM_ROOT]/gems/railties-5.0.0.1/lib/rails/commands/console_helper.rb", "line"=>9, "function"=>"start"}, {"file"=>"[GEM_ROOT]/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb", "line"=>78, "function"=>"console"}, {"file"=>"[GEM_ROOT]/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb", "line"=>49, "function"=>"run_command!"}, {"file"=>"[GEM_ROOT]/gems/railties-5.0.0.1/lib/rails/commands.rb", "line"=>18, "function"=>"<top (required)>"}, {"file"=>"bin/rails", "line"=>4, "function"=>"require"}, {"file"=>"bin/rails", "line"=>4, "function"=>"<main>"}]}], "context"=>{"rootDirectory"=>"/Users/xlu/cognoa", "environment"=>"development", "hostname"=>"Xiaomings-MacBook-Pro.local", "os"=>"x86_64-darwin16", "language"=>"ruby/2.3.3", "notifier"=>{"name"=>"airbrake-ruby", "version"=>"1.8.0", "url"=>"https://github.com/airbrake/airbrake-ruby"}}, "environment"=>{}, "session"=>{}, "params"=>{}, "key"=>"9e0f02cea5768843851546fdb78fd4bd", "project_id"=>"1", "notice"=>{}}
  Rendered problems/_tally_table.html.haml (48.5ms)
  Rendered mailer/err_notification.html.haml within layouts/mailer (82.5ms)
  Rendered mailer/err_notification.text.erb within layouts/mailer (3.1ms)
```
We need to save the request.env at that call to errbit notice object. When user visits errbit server env tab, it's a different request. Old code is using the 2nd request.env instead of the first. 

After the update, here is an example of env tab snapshot, notice the request method is now "POST" instead of "GET" which is correct since the server which generates the error is posting to the errbit server. 

<img width="1023" alt="screen shot 2017-03-20 at 11 47 25 pm" src="https://cloud.githubusercontent.com/assets/897450/24135626/26a950d0-0dc8-11e7-9a51-241c079eb2cb.png">


I tried to use the entire request.env, but always got bson error when saving the notice, so I add env variables one by one.

```
NoMethodError - undefined method `bson_type' for #<IO:<STDERR>>:
  bson (4.2.1) lib/bson/hash.rb:44:in `block in to_bson'
  bson (4.2.1) lib/bson/hash.rb:43:in `to_bson'
  bson (4.2.1) lib/bson/hash.rb:46:in `block in to_bson'
  bson (4.2.1) lib/bson/hash.rb:43:in `to_bson'
  bson (4.2.1) lib/bson/hash.rb:46:in `block in to_bson'
  bson (4.2.1) lib/bson/hash.rb:43:in `to_bson'
  bson (4.2.1) lib/bson/array.rb:49:in `block in to_bson'
  bson (4.2.1) lib/bson/array.rb:46:in `to_bson'
  bson (4.2.1) lib/bson/hash.rb:46:in `block in to_bson'
  bson (4.2.1) lib/bson/hash.rb:43:in `to_bson'
  mongo (2.4.1) lib/mongo/protocol/serializers.rb:163:in `serialize'
  mongo (2.4.1) lib/mongo/protocol/message.rb:213:in `block in serialize_fields'
  mongo (2.4.1) lib/mongo/protocol/message.rb:201:in `serialize_fields'
  mongo (2.4.1) lib/mongo/protocol/message.rb:104:in `serialize'
```

I tested even doing 
```
 environment = (params['environment'] || {}).merge(
... "session"=> {"isAdmin"=>true, "logger" => ActiveSupport::Logger.new("abc") }
)
```
will cause bson_type error. 
